### PR TITLE
Various UI improvements

### DIFF
--- a/apps/docs/src/docs/components/text-fields.md
+++ b/apps/docs/src/docs/components/text-fields.md
@@ -21,6 +21,7 @@ title: Text fields
 | `disabled`     | `boolean`                                 | Disables the text field        | `false`   |
 | `prefixText`   | `string`                                  | Prefix text of text field      | `null`    |
 | `suffixText`   | `string`                                  | Suffix text of text field      | `null`    |
+| `supportingText`   | `string`                                  | Supporting text of text field      | `null`    |
 
 ## Sub components
 

--- a/packages/actify/src/components/TextFields/FilledTextField.tsx
+++ b/packages/actify/src/components/TextFields/FilledTextField.tsx
@@ -132,7 +132,7 @@ const FilledTextField: React.FC<TextFieldProps> = forwardRef(
                       focused || populated
                         ? 'top-2 text-xs text-current'
                         : 'top-4 text-base text-on-surface'
-                    } absolute z-[1] overflow-hidden text-ellipsis whitespace-nowrap w-min max-w-full origin-top-left transition-all`}
+                    } absolute overflow-hidden text-ellipsis whitespace-nowrap w-min max-w-full origin-top-left transition-all`}
                   >
                     {label}
                     {required && '*'}

--- a/packages/actify/src/components/TextFields/OutlinedTextField.tsx
+++ b/packages/actify/src/components/TextFields/OutlinedTextField.tsx
@@ -126,7 +126,7 @@ const OutlinedTextField: React.FC<TextFieldProps> = forwardRef(
                   <span
                     className={`${
                       focused || populated ? 'opacity-0' : 'opacity-100'
-                    } absolute z-[1] overflow-hidden text-ellipsis whitespace-nowrap w-min max-w-full top-4 text-base text-on-surface`}
+                    } absolute overflow-hidden text-ellipsis whitespace-nowrap w-min max-w-full top-4 text-base text-on-surface`}
                   >
                     {label}
                     {required && '*'}

--- a/packages/actify/src/components/TextFields/TextField.tsx
+++ b/packages/actify/src/components/TextFields/TextField.tsx
@@ -4,12 +4,33 @@ import { FilledTextField } from './FilledTextField'
 import { OutlinedTextField } from './OutlinedTextField'
 import { LeadingIcon } from './LeadingIcon'
 import { TrailingIcon } from './TrailingIcon'
+import { tv } from 'tailwind-variants'
+
+const variants = tv({
+  base: 'cursor-text group',
+  variants: {
+    color: {
+      primary: 'text-on-surface-variant',
+      secondary: 'text-on-surface-variant',
+      tertiary: 'text-on-surface-variant',
+      error: 'text-error'
+    },
+    disabled: {
+      true: 'text-outline opacity-[.38] cursor-default'
+    }
+  },
+  defaultVariants: {
+    color: 'primary'
+  }
+})
 
 interface TextFieldRootProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string
   prefixText?: string
   suffixText?: string
+  supportingText?: string
+  color?: 'primary' | 'secondary' | 'tertiary' | 'error'
   variant?: 'filled' | 'outlined'
 }
 const TextField = forwardRef<HTMLInputElement, TextFieldRootProps>(
@@ -17,12 +38,13 @@ const TextField = forwardRef<HTMLInputElement, TextFieldRootProps>(
     const { variant = 'filled', ...rest } = props
 
     return (
-      <>
+      <div>
         {/* @ts-ignore */}
         {variant === 'filled' && <FilledTextField ref={ref} {...rest} />}
         {/* @ts-ignore */}
         {variant === 'outlined' && <OutlinedTextField ref={ref} {...rest} />}
-      </>
+        {props.supportingText && <p className={`text-xs mt-1 ms-3 ${variants({ color: props.color, disabled: props.disabled, className: props.className })}`}>{props.supportingText}</p>}
+      </div>
     )
   }
 )


### PR DESCRIPTION
I made some UI improvements to better align with Material 3 standards:
- Fixed issue where text field hint text (label) would appear above menu item
- Added supportingText for TextField

我做了一些UI改进让我们更符合 Material 3 的标准：
- 修复 TextField 的标签显示在 MenuItem 上的问题
- 在 TextField 加上了 supportingText 属性