### PR TITLE
Bug fixes for supporting text and custom CSS on text fields

### DIFF
--- a/packages/actify/src/components/TextFields/FilledTextField.tsx
+++ b/packages/actify/src/components/TextFields/FilledTextField.tsx
@@ -113,14 +113,11 @@ const FilledTextField: React.FC<TextFieldProps> = forwardRef(
         : 'text-on-surface-variant'
 
     return (
-      <div>
-        <div
-          className={
-            '[resize:inherit] [writing-mode:horizontal-tb] flex flex-1 flex-col max-w-full ' +
-            variants({ color, disabled, className })
-          }
-          onClick={handleClick}
-        >
+      <div className={
+        '[resize:inherit] [writing-mode:horizontal-tb] flex flex-1 flex-col max-w-full ' +
+        variants({ color, disabled, className })
+      }>
+        <div onClick={handleClick}>
           {/* container-overflow */}
           <div className="relative flex h-full rounded-t">
             {/* background */}

--- a/packages/actify/src/components/TextFields/OutlinedTextField.tsx
+++ b/packages/actify/src/components/TextFields/OutlinedTextField.tsx
@@ -113,14 +113,11 @@ const OutlinedTextField: React.FC<TextFieldProps> = forwardRef(
         : 'text-on-surface-variant'
 
     return (
-      <div>
-        <div
-          className={
-            '[resize:inherit] [writing-mode:horizontal-tb] flex flex-1 flex-col max-w-full ' +
-            variants({ color, disabled, className })
-          }
-          onClick={handleClick}
-        >
+      <div className={
+        '[resize:inherit] [writing-mode:horizontal-tb] flex flex-1 flex-col max-w-full ' +
+        variants({ color, disabled, className })
+      }>
+        <div onClick={handleClick}>
           {/* container-overflow */}
           <div className="relative flex h-full rounded">
             {/* container */}


### PR DESCRIPTION
Fixed bug where className on TextFields would apply to the main text field and not include the supporting text.