### PR TITLE
fix(CarouselControl): Reset autoplay interval on user interaction

### DIFF
--- a/packages/actify/src/components/Carousel/CarouselControl.tsx
+++ b/packages/actify/src/components/Carousel/CarouselControl.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx'
 import styles from './carousel-control.module.css'
 import { useCarousel } from './CarouselContext'
 import { useInterval } from './../../hooks'
+import { PressEvent } from 'react-aria-components'
 
 type CarouselControlProps = {
   control?: boolean
@@ -20,21 +21,26 @@ const CarouselControl = ({
   infinite
 }: CarouselControlProps) => {
   const { total, page, setPage, current, interval } = useCarousel()
+  const [pressCount, setPressCount] = React.useState(0)
 
-  const prev = () => {
+  const prev = (e?: PressEvent) => {
     if (!infinite && current == 0) {
       return
     }
-    setPage?.([(page ? Number(page[0]) : 0) - 1, -1])
+    setPage?.([(page?.[0] ?? 0) - 1, -1])
+    if (e) setPressCount((old) => old + 1)
   }
-  const next = () => {
+  const next = (e?: PressEvent) => {
     if (!infinite && current == (total ?? 0) - 1) {
       return
     }
-    setPage?.([(page ? Number(page[0]) : 0) + 1, 1])
+    setPage?.([(page?.[0] ?? 0) + 1, 1])
+    if (e) setPressCount((old) => old + 1)
   }
 
-  autoPlay && useInterval(next, interval ?? 0)
+  if (autoPlay) {
+    useInterval(next, interval ?? 0, [pressCount])
+  }
 
   return (
     control && (

--- a/packages/actify/src/hooks/useInterval.ts
+++ b/packages/actify/src/hooks/useInterval.ts
@@ -2,7 +2,11 @@
 
 import { useEffect, useRef } from 'react'
 
-const useInterval = (callback: () => void, delay: number | null) => {
+const useInterval = (
+  callback: () => void,
+  delay: number | null,
+  dependencies: unknown[] = []
+) => {
   const savedCallback = useRef(callback)
 
   useEffect(() => {
@@ -15,6 +19,6 @@ const useInterval = (callback: () => void, delay: number | null) => {
     }
     const id = setInterval(() => savedCallback.current(), delay)
     return () => clearInterval(id)
-  }, [delay])
+  }, [delay, ...dependencies])
 }
 export { useInterval }


### PR DESCRIPTION
Closes #31

> The carousel's autoplay feature is a simple useInterval that calls the next function, [...] the interval is not reset when the user manually controls the carousel, it leads to weird results based on the user's timing.

I was initially worried that I'd write some horrible code, but then I had the epiphany of (ab)using React's dependency tracking.
I feel proud of how neat this looks.
