### PR TITLE
Update Menus visuals and fix scroll bug

### DIFF
--- a/apps/docs/content/components/focus-ring.md
+++ b/apps/docs/content/components/focus-ring.md
@@ -5,3 +5,11 @@ title: Focus Ring
 ## Usage
 
 <usage></usage>
+
+## Props
+| Name      | Type                                              | Description                                                                               | Default   |
+| --------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------- |
+| type      | `outward` `inward`                                | The way the focus ring is animated and positioned.                                        | `outward` |
+| as        | `keyof HTMLElementTagNameMap` `React.ElementType` | Allows for more flexibility when supporting different elements that can act as a FocusRing. | `span`    |
+| style     | `React.CSSProperties`                             | —                                                                                         | —         |
+| className | `string`                                          | —                                                                                         | —         |

--- a/apps/docs/content/components/menus.md
+++ b/apps/docs/content/components/menus.md
@@ -8,8 +8,28 @@ description: Menus display a list of choices on a temporary surface
 <usage></usage>
 
 ## Props
+### MenuButton
 
-| Name        | Type           | Description                          | Default |
-| ----------- | -------------- | ------------------------------------ | ------- |
-| `label`     | `string`       | The text to show on the menu button. | `null`  |
-| `activator` | `render props` | activator component of the menu.     | `null`  |
+| Name                | Type                | Description                                                                 | Default |
+| ------------------- | ------------------- | --------------------------------------------------------------------------- | ------- |
+| `label`             | `React.ReactNode`   | The text to show on the menu button.                                        | —       |
+| `popoverProps`      | `PopoverProps`      | Props that allow changing the popover placement, flip behavior, style etc.  | —       |
+
+### MenuItem
+
+| Name                | Type                  | Description                                                                       | Default |
+| ------------------- | --------------------- | --------------------------------------------------------------------------------- | ------- |
+| `textValue`         | `string`              | A string representation of the item's contents, used for features like typeahead. | —       |
+| `isDisabled`        | `boolean`             | Whether the item is disabled.                                                     | `false` |
+| `className`         | `string`              | —                                                                                 | —       |
+| `style`             | `React.CSSProperties` | —                                                                                 | —       |
+
+## Events
+### MenuItem
+
+| Name              | Type                              | Description                                              |
+| ----------------- | --------------------------------- | -------------------------------------------------------- |
+| `onAction`        | `() => void`                      | Handler that is called when the item is selected.        |
+| `onHoverChange`   | `(isHovering: boolean) => void`   | Handler that is called when the hover state changes.     |
+| `onHoverStart`    | `(e: HoverEvent) => void`         | Handler that is called when a hover interaction starts.  |
+| `onHoverEnd`      | `(e: HoverEvent) => void`         | Handler that is called when a hover interaction ends.    |

--- a/apps/docs/content/components/select.md
+++ b/apps/docs/content/components/select.md
@@ -6,3 +6,31 @@ description: Select fields components are used for collecting user provided info
 ## Usage
 
 <usage></usage>
+
+## Props
+
+| Name                  | Type                  | Default        | Description                                                                                                   |
+| --------------------- | --------------------- | -------------- | ------------------------------------------------------------------------------------------------------------- |
+| `label`               | `React.ReactNode`     | —              | The content to display as the label.                                                                          |
+| `selectedKey`         | `Key`                 | —              | The currently selected key in the collection (controlled).                                                    |
+| `disabledKeys`        | `Iterable<Key>`       | —              | The item keys that are disabled. These items cannot be selected, focused, or otherwise interacted with.       |
+| `isOpen`              | `boolean`             | `false`        | Sets the open state of the menu.                                                                              |
+| `isDisabled`          | `boolean`             | `false`        | Whether the input is disabled.                                                                                |
+| `isRequired`          | `boolean`             | `false`        | Whether user input is required on the input before form submission.                                           |
+| `isInvalid`           | `boolean`             | `false`        | Whether the input value is invalid.                                                                           |
+| `validationBehavior`  | `aria` `native`       | `aria`         | Whether to use native HTML form validation to prevent form submission when the value is missing or invalid, or mark the field as required or invalid via ARIA. |
+| `validate`            | `(value: Key) => ValidationError` `true` | — | A function that returns an error message if a given value is invalid. Validation errors are displayed to the user when the form is submitted if validationBehavior="native". For realtime validation, use the isInvalid prop instead. |
+| `variant`             | `filled` `outlined`   | `filled`       | The type of the Select.                                                                                       |
+| `popoverProps`        | `PopoverProps`        | —              | Props that allow changing the popover placement, flip behavior, style etc.                                    |
+| `className`           | `string`              | —              | —                                                                                                             |
+| `style`               | `React.CSSProperties` | —              | —                                                                                                             |
+
+## Events
+
+| Name                | Type                            | Description                                                       |
+| ------------------- | ------------------------------- | ----------------------------------------------------------------- |
+| `onSelectionChange` | `(key: Key) => void`            | Handler that is called when the selection changes.                |
+| `onBlur`            | `(e: React.FocusEvent) => void` | Handler that is called when the element loses focus.              |
+| `onFocus`           | `(e: React.FocusEvent) => void` | Handler that is called when the element receives focus.           |
+| `onFocusChange`     | `(isFocused: boolean) => void`  | Handler that is called when the element's focus status changes.   |
+| `onOpenChange`      | `(isOpened: boolean) => void`   | Method that is called when the open state of the menu changes.    |

--- a/apps/docs/src/usages/focus-ring.tsx
+++ b/apps/docs/src/usages/focus-ring.tsx
@@ -1,11 +1,28 @@
 import { FocusRing, useFocusRing } from 'actify'
+import React from 'react'
 
-export default () => {
+function FocusRingInput({ inward }: {inward?: boolean}) {
   const { isFocused, focusProps } = useFocusRing()
+
   return (
     <span className="relative">
-      <input {...focusProps} className="outline-none text-primary" />
-      {isFocused && <FocusRing />}
+      <input {...focusProps} className="outline-none text-primary"/>
+      {isFocused && <FocusRing type={inward ? 'inward' : 'outward'} />}
     </span>
+  );
+}
+
+export default () => {
+  return (
+    <div className="flex items-center gap-4">
+      <div className='relative mb-2'>
+        <h6>type outward</h6>
+        <FocusRingInput />
+      </div>
+      <div className='relative mb-2'>
+        <h6>type inward</h6>
+        <FocusRingInput inward />
+      </div>
+    </div>
   )
 }

--- a/apps/docs/src/usages/select.tsx
+++ b/apps/docs/src/usages/select.tsx
@@ -3,20 +3,45 @@ import { Select, SelectOption } from 'actify'
 import React from 'react'
 
 export default () => {
+  const [selectedKey, setSelectedKey] = React.useState("");
+
+  const options = [
+    {id: "actify", value: "Actify"},
+    {id: "ngroker", value: "Ngroker"},
+    {id: "taildoor", value: "Taildoor"},
+    {id: "hugola", value: "Hugola"}
+  ];
+
   return (
-    <div className="max-sm:flex-wrap flex gap-4">
-      <Select label="Select Project">
-        <SelectOption>Actify</SelectOption>
-        <SelectOption>Ngroker</SelectOption>
-        <SelectOption>Taildoor</SelectOption>
-        <SelectOption>Hugola</SelectOption>
-      </Select>
-      <Select variant="outlined" label="Select Project">
-        <SelectOption>Actify</SelectOption>
-        <SelectOption>Ngroker</SelectOption>
-        <SelectOption>Taildoor</SelectOption>
-        <SelectOption>Hugola</SelectOption>
-      </Select>
+    <div className="flex flex-col gap-5">
+      <div className="max-sm:flex-wrap flex gap-4">
+        <Select label="Select Project">
+          <SelectOption>Actify</SelectOption>
+          <SelectOption>Ngroker</SelectOption>
+          <SelectOption>Taildoor</SelectOption>
+          <SelectOption>Hugola</SelectOption>
+        </Select>
+        <Select variant="outlined" label="Select Project">
+          <SelectOption>Actify</SelectOption>
+          <SelectOption>Ngroker</SelectOption>
+          <SelectOption>Taildoor</SelectOption>
+          <SelectOption>Hugola</SelectOption>
+        </Select>
+      </div>
+      <div>
+        <h6 className='mb-3 font-semibold'>Controlled Example:</h6>
+        <Select variant="outlined" label="Controlled Select" selectedKey={selectedKey}
+        onSelectionChange={key => setSelectedKey(key.toString())}>
+          <>
+          {options.map((option) => (
+            <SelectOption key={option.id}>
+              {option.value}
+            </SelectOption>
+          ))}
+          </>
+        </Select>
+        <p className='mt-1'>Selected key: {selectedKey}</p>
+      </div>
     </div>
   )
 }

--- a/packages/actify/src/components/FocusRing/FocusRing.tsx
+++ b/packages/actify/src/components/FocusRing/FocusRing.tsx
@@ -5,11 +5,12 @@ import styles from './focusring.module.css'
 type FocusRingProps = {
   style?: CSSProperties
   className?: string
+  type?: 'outward' | 'inward'
   as?: keyof HTMLElementTagNameMap | React.ElementType
 }
 
-const FocusRing = ({ as: As = 'span', style, className }: FocusRingProps) => {
-  return <As style={style} className={clsx(styles['focus-ring'], className)} />
+const FocusRing = ({ as: As = 'span', type = 'outward', style, className }: FocusRingProps) => {
+  return <As style={style} className={clsx(styles['focus-ring'], className)} inward={type === 'inward' ? 'true' : undefined}/>
 }
 
 FocusRing.displayName = 'Actify.FocusRing'

--- a/packages/actify/src/components/FocusRing/focusring.module.css
+++ b/packages/actify/src/components/FocusRing/focusring.module.css
@@ -45,21 +45,8 @@
   }
   &[inward] {
     animation-name: inward-grow, inward-shrink;
-    border-end-end-radius: calc(
-      var(--md-focus-ring-shape-end-end, var(--md-focus-ring-shape, 9999px)) -
-        var(--md-focus-ring-inward-offset, 0px)
-    );
-    border-end-start-radius: calc(
-      var(--md-focus-ring-shape-end-start, var(--md-focus-ring-shape, 9999px)) -
-        var(--md-focus-ring-inward-offset, 0px)
-    );
-    border-start-end-radius: calc(
-      var(--md-focus-ring-shape-start-end, var(--md-focus-ring-shape, 9999px)) -
-        var(--md-focus-ring-inward-offset, 0px)
-    );
-    border-start-start-radius: calc(
-      var(--md-focus-ring-shape-start-start, var(--md-focus-ring-shape, 9999px)) -
-        var(--md-focus-ring-inward-offset, 0px)
+    border-radius: calc(
+      var(--md-focus-ring-shape, inherit) - var(--md-focus-ring-inward-offset, 0px)
     );
     border: var(--md-focus-ring-width, 3px) solid currentColor;
     inset: var(--md-focus-ring-inward-offset, 0px);

--- a/packages/actify/src/components/ListBox/ListBoxOption.tsx
+++ b/packages/actify/src/components/ListBox/ListBoxOption.tsx
@@ -36,10 +36,11 @@ const ListBoxOption = <T extends object>({
       {item.rendered}
       {isFocusVisible && (
         <FocusRing
+          type="inward"
           style={
             {
               color: 'rgb(var(--md-sys-color-primary))',
-              '--md-focus-ring-outward-offset': '-3px'
+              '--md-focus-ring-shape': "8px"
             } as React.CSSProperties
           }
         />

--- a/packages/actify/src/components/ListBox/listbox.module.css
+++ b/packages/actify/src/components/ListBox/listbox.module.css
@@ -2,9 +2,7 @@
   list-style: none;
   margin: 0;
   display: block;
-  padding-left: 8px;
   padding-block: 8px;
-  padding-right: 8px;
   list-style-type: none;
   outline: none;
   box-sizing: border-box;

--- a/packages/actify/src/components/ListBox/option.module.css
+++ b/packages/actify/src/components/ListBox/option.module.css
@@ -1,5 +1,6 @@
 .item {
   display: flex;
+  align-items: center;
   cursor: pointer;
   position: relative;
   --md-ripple-hover-color: var(

--- a/packages/actify/src/components/Menus/ListBoxItem.tsx
+++ b/packages/actify/src/components/Menus/ListBoxItem.tsx
@@ -18,7 +18,7 @@ const ListBoxItem = ({ style, className, ...props }: ListBoxItemProps) => {
       className={clsx(styles['item'], className)}
     >
       <>{props.children}</>
-      <FocusRing className={styles['focus-ring']} />
+      <FocusRing className={styles['focus-ring']} type="inward" />
       <Ripple />
     </AriaListBoxItem>
   )

--- a/packages/actify/src/components/Menus/MenuButton.tsx
+++ b/packages/actify/src/components/Menus/MenuButton.tsx
@@ -4,24 +4,26 @@ import { MenuProps, MenuTrigger, MenuTriggerProps } from 'react-aria-components'
 
 import { Button } from '../Buttons'
 import { Menu } from './Menu'
-import { MenuPopover } from './MenuPopover'
+import { MenuPopover, PopoverProps } from './MenuPopover'
 import React from 'react'
 
 export interface MenuButtonProps<T>
   extends MenuProps<T>,
     Omit<MenuTriggerProps, 'children'> {
-  label?: React.ReactNode
+  label?: React.ReactNode;
+  popoverProps?: Omit<PopoverProps, 'children'>;
 }
 
 const MenuButton = <T extends object>({
   label,
   children,
+  popoverProps,
   ...props
 }: MenuButtonProps<T>) => {
   return (
     <MenuTrigger {...props}>
       {typeof label == 'string' ? <Button>{label}</Button> : label}
-      <MenuPopover>
+      <MenuPopover {...popoverProps}>
         <Menu>{children}</Menu>
       </MenuPopover>
     </MenuTrigger>

--- a/packages/actify/src/components/Menus/MenuItem.tsx
+++ b/packages/actify/src/components/Menus/MenuItem.tsx
@@ -39,10 +39,11 @@ const MenuItem = (props: MenuItemProps) => {
           </Item>
           {isFocusVisible && (
             <FocusRing
+              type="inward"
               style={
                 {
                   color: 'rgb(var(--md-sys-color-primary))',
-                  '--md-focus-ring-outward-offset': '-3px'
+                  '--md-focus-ring-shape': "8px"
                 } as React.CSSProperties
               }
             />

--- a/packages/actify/src/components/Menus/MenuPopover.tsx
+++ b/packages/actify/src/components/Menus/MenuPopover.tsx
@@ -17,6 +17,12 @@ export interface PopoverProps extends Omit<AriaPopoverProps, 'children'> {
 }
 
 const MenuPopover = ({ children, ...props }: PopoverProps) => {
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+
+  const onAnimationComplete = React.useCallback(() => {
+    dialogRef.current?.classList.add(styles['open']);
+  }, [dialogRef])
+
   // make the width of the popover the same as the reference element
   if (props.referenceWidth) {
     props.style = {
@@ -33,14 +39,16 @@ const MenuPopover = ({ children, ...props }: PopoverProps) => {
           overflow: 'hidden'
         }}
         animate={{
-          height: 'auto'
+          height: 'auto',
+          maxHeight: 'inherit',
         }}
         transition={{
           duration: 0.3
         }}
+        onAnimationComplete={onAnimationComplete}
       >
         <OverlayArrow className={styles['underlay']} />
-        <Dialog aria-label="dialog" className={styles['dialog']}>
+        <Dialog aria-label="dialog" className={styles['dialog']} ref={dialogRef}>
           {children}
         </Dialog>
       </motion.div>

--- a/packages/actify/src/components/Menus/MenuPopover.tsx
+++ b/packages/actify/src/components/Menus/MenuPopover.tsx
@@ -10,6 +10,7 @@ import {
 import React from 'react'
 import { motion } from 'motion/react'
 import styles from './menu-popover.module.css'
+import clsx from 'clsx'
 
 export interface PopoverProps extends Omit<AriaPopoverProps, 'children'> {
   children: React.ReactNode
@@ -32,7 +33,7 @@ const MenuPopover = ({ children, ...props }: PopoverProps) => {
   }
 
   return (
-    <AriaPopover {...props} style={props.style} className={styles['popover']}>
+    <AriaPopover {...props} style={props.style} className={clsx(styles['popover'], props.className)}>
       <motion.div
         initial={{
           height: 0,

--- a/packages/actify/src/components/Menus/listbox.module.css
+++ b/packages/actify/src/components/Menus/listbox.module.css
@@ -2,9 +2,7 @@
   list-style: none;
   margin: 0;
   display: block;
-  padding-left: 8px;
   padding-block: 8px;
-  padding-right: 8px;
   list-style-type: none;
   outline: none;
   box-sizing: border-box;

--- a/packages/actify/src/components/Menus/menu-popover.module.css
+++ b/packages/actify/src/components/Menus/menu-popover.module.css
@@ -28,3 +28,7 @@
   );
   scrollbar-width: inherit;
 }
+
+.dialog.open {
+  overflow: auto;
+}

--- a/packages/actify/src/components/Menus/menu-popover.module.css
+++ b/packages/actify/src/components/Menus/menu-popover.module.css
@@ -1,3 +1,9 @@
+.popover {
+  box-shadow: 0 2px 6px 2px rgb(0, 0, 0, .15);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
 .popover:focus-visible {
   outline: none;
 }

--- a/packages/actify/src/components/Menus/menu.module.css
+++ b/packages/actify/src/components/Menus/menu.module.css
@@ -53,7 +53,7 @@
   box-sizing: border-box;
   list-style: none;
   margin: 0;
-  padding: 8px;
+  padding-block: 8px;
   --md-ripple-hover-color: var(
     --md-menu-item-hover-state-layer-color,
     rgb(var(--md-sys-color-on-surface))

--- a/packages/actify/src/components/Popover/Popover.tsx
+++ b/packages/actify/src/components/Popover/Popover.tsx
@@ -17,6 +17,7 @@ import type {
 import React from 'react'
 import { RenderProps, SlotProps } from './../../utils'
 import { OverlayTriggerState } from 'react-stately'
+import clsx from 'clsx'
 
 interface PopoverRenderProps {
   /**
@@ -94,7 +95,7 @@ const Popover = (props: PopoverProps & React.RefAttributes<HTMLElement>) => {
       {/* @ts-expect-error */}
       <motion.div
         {...popoverProps}
-        className={styles['popover']}
+        className={clsx(styles['popover'], props.className)}
         initial={{
           height: 0,
           overflow: 'hidden'

--- a/packages/actify/src/components/Popover/Popover.tsx
+++ b/packages/actify/src/components/Popover/Popover.tsx
@@ -83,6 +83,11 @@ const Popover = (props: PopoverProps & React.RefAttributes<HTMLElement>) => {
     } as React.CSSProperties
   }
 
+  // apply a class that enables scrolling if necessary
+  const onAnimationComplete = React.useCallback(() => {
+    popoverRef.current?.classList.add(styles['open']);
+  }, [popoverRef])
+
   return (
     <Overlay>
       <div {...underlayProps} className={styles['underlay']} />
@@ -91,8 +96,10 @@ const Popover = (props: PopoverProps & React.RefAttributes<HTMLElement>) => {
         {...popoverProps}
         className={styles['popover']}
         initial={{
-          height: 0
+          height: 0,
+          overflow: 'hidden'
         }}
+        onAnimationComplete={onAnimationComplete}
         animate={{
           height: 'auto'
         }}

--- a/packages/actify/src/components/Popover/popover.module.css
+++ b/packages/actify/src/components/Popover/popover.module.css
@@ -22,6 +22,7 @@
     var(--md-sys-shape-corner-extra-small, 4px)
   );
   scrollbar-width: inherit;
+  box-shadow: 0 2px 6px 2px rgba(0, 0, 0, .15);
 }
 
 .popover > ul {

--- a/packages/actify/src/components/Popover/popover.module.css
+++ b/packages/actify/src/components/Popover/popover.module.css
@@ -23,6 +23,11 @@
   );
   scrollbar-width: inherit;
 }
+
 .popover > ul {
   overflow: hidden;
+}
+
+.popover.open > ul {
+  overflow: auto;
 }

--- a/packages/actify/src/components/Select/Select.tsx
+++ b/packages/actify/src/components/Select/Select.tsx
@@ -1,11 +1,11 @@
-import { AriaSelectOptions, HiddenSelect, useSelect } from 'react-aria'
+import { AriaSelectOptions, HiddenSelect, Placement, useSelect } from 'react-aria'
 import { SelectStateOptions, useSelectState } from 'react-stately'
 
 import { FilledField } from './FilledField'
 import { Label } from '../Label/Label'
 import { ListBox } from '../ListBox'
 import { OutlinedField } from './OutlinedField'
-import { Popover } from '../Popover/Popover'
+import { Popover, PopoverProps } from '../Popover/Popover'
 import React from 'react'
 import { TrailingIcon } from './TrailingIcon'
 import clsx from 'clsx'
@@ -17,6 +17,7 @@ interface SelectProps<T> extends AriaSelectOptions<T>, SelectStateOptions<T> {
   style?: React.CSSProperties
   leadingIcon?: React.ReactNode
   trailingIcon?: React.ReactNode
+  popoverProps?: Omit<PopoverProps, 'state'>
   variant?: 'filled' | 'outlined'
 }
 
@@ -26,7 +27,7 @@ const Select = <T extends object>(props: SelectProps<T>) => {
 
   const { triggerProps, valueProps, menuProps } = useSelect(props, state, ref)
 
-  const { variant = 'filled' } = props
+  const { variant = 'filled', popoverProps } = props;
 
   let Tag = FilledField
   if (variant == 'filled') {
@@ -63,8 +64,9 @@ const Select = <T extends object>(props: SelectProps<T>) => {
           offset={2}
           state={state}
           triggerRef={ref}
-          placement="bottom start"
           referenceWidth={referenceWidth}
+          placement={popoverProps?.placement ?? 'bottom start'}
+          {...popoverProps}
         >
           <ListBox {...menuProps} state={state} />
         </Popover>


### PR DESCRIPTION
## Summary
* Adds the possibility for an inward focus ring
* Fixes a bug where the scrollbar would not appear when the content exceeded the max-height of popovers
* Updates Menus style (shadow, padding etc)
* Adds the possibility to pass props to popovers via MenuButtons and Selects
* Updates the changed components in docs

## Main changes
### Inward focus ring animation
![focus-ring](https://github.com/user-attachments/assets/554cec03-a86a-43b6-bd18-b9f5cece5243)

### Scroll bug fix
Before                    | After
:--------------------:|:---------------------------------:
![scroll-before](https://github.com/user-attachments/assets/e0b7a5b6-a76c-4acf-a3ab-dec4d8313994) | ![scroll-after](https://github.com/user-attachments/assets/a5ebc136-65f7-42af-902f-cfe2dcca60f7)

### Updated style
(The inward focus ring is used here)

<img src="https://github.com/user-attachments/assets/97e5c712-fed6-4fe4-9802-04cd95f85535" alt="select-menu-new-style" width="350">